### PR TITLE
twid & twrc

### DIFF
--- a/dist/validid.js
+++ b/dist/validid.js
@@ -100,18 +100,16 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
           };
 
           isChecksumValid = function isChecksumValid(id) {
-            var _char2, i, idLen, idTail, len, letterIndex, letterValue, letters, remainder, weight, weightedSum;
+            var _char2, i, idLen, idTail, len, letterIndex, letters, remainder, weight, weightedSum;
 
             idLen = id.length; // each letter represents value from [10..35]
 
             letters = 'ABCDEFGHJKLMNPQRSTUVXYWZIO';
-            letterIndex = letters.indexOf(id[0]) + 10;
-            letterValue = Math.floor(letterIndex / 10) + letterIndex % 10 * (idLen - 1);
+            letterIndex = letters.indexOf(id[0]);
+            weightedSum = Math.floor(letterIndex / 10 + 1) + letterIndex * (idLen - 1);
             idTail = id.slice(1); // drop the letter
 
             weight = idLen - 2; // minus letter digit and check digit
-
-            weightedSum = 0;
 
             for (i = 0, len = idTail.length; i < len; i++) {
               _char2 = idTail[i];
@@ -120,7 +118,7 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
             } // note: the check digit of 'id' is weighted 0
 
 
-            remainder = (letterValue + weightedSum + +id.slice(-1)) % 10;
+            remainder = (weightedSum + +id.slice(-1)) % 10;
             return remainder === 0;
           };
 
@@ -141,15 +139,14 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
           };
 
           isChecksumValid = function isChecksumValid(id) {
-            var _char3, i, idLen, idTail, len, letter2Index, letterIndex, letters, remainder, weight, weightedSum;
+            var _char3, i, idLen, idTail, len, letterIndex, letters, remainder, weight, weightedSum;
 
             idLen = id.length; // each letter represents value from [10..35]
 
             letters = 'ABCDEFGHJKLMNPQRSTUVXYWZIO';
-            letterIndex = letters.indexOf(id[0]) + 10;
-            weightedSum = Math.floor(letterIndex / 10) + letterIndex % 10 * (idLen - 1);
-            letter2Index = letters.indexOf(id[1]);
-            weightedSum += letter2Index * (idLen - 2);
+            letterIndex = letters.indexOf(id[0]);
+            weightedSum = Math.floor(letterIndex / 10 + 1) + letterIndex * (idLen - 1);
+            weightedSum += letters.indexOf(id[1]) * (idLen - 2);
             idTail = id.slice(2); // drop the letters
 
             weight = idLen - 3; // minus letter digit and check digit

--- a/lib/validid.js
+++ b/lib/validid.js
@@ -100,18 +100,16 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
           };
 
           isChecksumValid = function isChecksumValid(id) {
-            var _char2, i, idLen, idTail, len, letterIndex, letterValue, letters, remainder, weight, weightedSum;
+            var _char2, i, idLen, idTail, len, letterIndex, letters, remainder, weight, weightedSum;
 
             idLen = id.length; // each letter represents value from [10..35]
 
             letters = 'ABCDEFGHJKLMNPQRSTUVXYWZIO';
-            letterIndex = letters.indexOf(id[0]) + 10;
-            letterValue = Math.floor(letterIndex / 10) + letterIndex % 10 * (idLen - 1);
+            letterIndex = letters.indexOf(id[0]);
+            weightedSum = Math.floor(letterIndex / 10 + 1) + letterIndex * (idLen - 1);
             idTail = id.slice(1); // drop the letter
 
             weight = idLen - 2; // minus letter digit and check digit
-
-            weightedSum = 0;
 
             for (i = 0, len = idTail.length; i < len; i++) {
               _char2 = idTail[i];
@@ -120,7 +118,7 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
             } // note: the check digit of 'id' is weighted 0
 
 
-            remainder = (letterValue + weightedSum + +id.slice(-1)) % 10;
+            remainder = (weightedSum + +id.slice(-1)) % 10;
             return remainder === 0;
           };
 
@@ -141,15 +139,14 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
           };
 
           isChecksumValid = function isChecksumValid(id) {
-            var _char3, i, idLen, idTail, len, letter2Index, letterIndex, letters, remainder, weight, weightedSum;
+            var _char3, i, idLen, idTail, len, letterIndex, letters, remainder, weight, weightedSum;
 
             idLen = id.length; // each letter represents value from [10..35]
 
             letters = 'ABCDEFGHJKLMNPQRSTUVXYWZIO';
-            letterIndex = letters.indexOf(id[0]) + 10;
-            weightedSum = Math.floor(letterIndex / 10) + letterIndex % 10 * (idLen - 1);
-            letter2Index = letters.indexOf(id[1]);
-            weightedSum += letter2Index * (idLen - 2);
+            letterIndex = letters.indexOf(id[0]);
+            weightedSum = Math.floor(letterIndex / 10 + 1) + letterIndex * (idLen - 1);
+            weightedSum += letters.indexOf(id[1]) * (idLen - 2);
             idTail = id.slice(2); // drop the letters
 
             weight = idLen - 3; // minus letter digit and check digit

--- a/src/validid.coffee
+++ b/src/validid.coffee
@@ -163,16 +163,15 @@ class Validid
       idLen = id.length
       # each letter represents value from [10..35]
       letters = 'ABCDEFGHJKLMNPQRSTUVXYWZIO'
-      letterIndex = letters.indexOf(id[0]) + 10
-      letterValue = Math.floor(letterIndex / 10) + (letterIndex % 10) * (idLen - 1)
+      letterIndex = letters.indexOf(id[0])
+      weightedSum = Math.floor(letterIndex / 10 + 1) + letterIndex * (idLen - 1)
       idTail = id.slice(1) # drop the letter
       weight = idLen - 2 # minus letter digit and check digit
-      weightedSum = 0
       for char in idTail
         weightedSum += +char * weight
         weight--
       # note: the check digit of 'id' is weighted 0
-      remainder = (letterValue + weightedSum + +id.slice(-1)) % 10
+      remainder = (weightedSum + +id.slice(-1)) % 10
       remainder is 0
 
     id = @tools.normalize(id)
@@ -192,10 +191,9 @@ class Validid
       idLen = id.length
       # each letter represents value from [10..35]
       letters = 'ABCDEFGHJKLMNPQRSTUVXYWZIO'
-      letterIndex = letters.indexOf(id[0]) + 10
-      weightedSum = Math.floor(letterIndex / 10) + (letterIndex % 10) * (idLen - 1)
-      letter2Index = letters.indexOf(id[1])
-      weightedSum += letter2Index * (idLen - 2)
+      letterIndex = letters.indexOf(id[0])
+      weightedSum = Math.floor(letterIndex / 10 + 1) + letterIndex * (idLen - 1)
+      weightedSum += letters.indexOf(id[1]) * (idLen - 2)
       idTail = id.slice(2) # drop the letters
       weight = idLen - 3 # minus letter digit and check digit
       for char in idTail

--- a/test/validid.js
+++ b/test/validid.js
@@ -100,18 +100,16 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
           };
 
           isChecksumValid = function isChecksumValid(id) {
-            var _char2, i, idLen, idTail, len, letterIndex, letterValue, letters, remainder, weight, weightedSum;
+            var _char2, i, idLen, idTail, len, letterIndex, letters, remainder, weight, weightedSum;
 
             idLen = id.length; // each letter represents value from [10..35]
 
             letters = 'ABCDEFGHJKLMNPQRSTUVXYWZIO';
-            letterIndex = letters.indexOf(id[0]) + 10;
-            letterValue = Math.floor(letterIndex / 10) + letterIndex % 10 * (idLen - 1);
+            letterIndex = letters.indexOf(id[0]);
+            weightedSum = Math.floor(letterIndex / 10 + 1) + letterIndex * (idLen - 1);
             idTail = id.slice(1); // drop the letter
 
             weight = idLen - 2; // minus letter digit and check digit
-
-            weightedSum = 0;
 
             for (i = 0, len = idTail.length; i < len; i++) {
               _char2 = idTail[i];
@@ -120,7 +118,7 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
             } // note: the check digit of 'id' is weighted 0
 
 
-            remainder = (letterValue + weightedSum + +id.slice(-1)) % 10;
+            remainder = (weightedSum + +id.slice(-1)) % 10;
             return remainder === 0;
           };
 
@@ -141,15 +139,14 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
           };
 
           isChecksumValid = function isChecksumValid(id) {
-            var _char3, i, idLen, idTail, len, letter2Index, letterIndex, letters, remainder, weight, weightedSum;
+            var _char3, i, idLen, idTail, len, letterIndex, letters, remainder, weight, weightedSum;
 
             idLen = id.length; // each letter represents value from [10..35]
 
             letters = 'ABCDEFGHJKLMNPQRSTUVXYWZIO';
-            letterIndex = letters.indexOf(id[0]) + 10;
-            weightedSum = Math.floor(letterIndex / 10) + letterIndex % 10 * (idLen - 1);
-            letter2Index = letters.indexOf(id[1]);
-            weightedSum += letter2Index * (idLen - 2);
+            letterIndex = letters.indexOf(id[0]);
+            weightedSum = Math.floor(letterIndex / 10 + 1) + letterIndex * (idLen - 1);
+            weightedSum += letters.indexOf(id[1]) * (idLen - 2);
             idTail = id.slice(2); // drop the letters
 
             weight = idLen - 3; // minus letter digit and check digit


### PR DESCRIPTION
It should still work the same due to mod 10 for remainder calculation.

---

Currently the code for _Taiwan Resident Certificate_ weighted sum of letter2 is

`weightedSum += letter2Index * (idLen - 2)`

It really should be

`weightedSum += (letter2Index % 10) * (idLen - 2)`

It works anyway since the weighted sum is % 10 at the end one more time.
So for consistency either fix that line or remove % 10 from weighted sum calculation for letterIndex for twid and twrc like proposed in this pull request.